### PR TITLE
docs: fix string in example

### DIFF
--- a/docs/guides/decoding-strategy.md
+++ b/docs/guides/decoding-strategy.md
@@ -23,7 +23,7 @@ Given that we have the given secret information:
 {
     "name": "Gustavo",
     "surname": "Fring",
-    "address":"aGFwcHkgc3RyZWV0",
+    "address": "happy street",
 }
 ```
 if we apply the following dataFrom:


### PR DESCRIPTION
## Problem Statement

The address in the first example should be the base64-decoded string.

## Proposed Changes

This is just a simple documentation fix.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage: Does not apply
- [x] All tests pass with `make test`: Does not apply
- [x] I ensured my PR is ready for review with `make reviewable`
